### PR TITLE
typo fix

### DIFF
--- a/anandkumar15a/info.json
+++ b/anandkumar15a/info.json
@@ -1,8 +1,7 @@
 {
     "abstract": "Overcomplete latent representations have been very popular for unsupervised feature learning in recent years. In this paper, we specify which overcomplete models can be identified given observable moments of a certain order. We consider probabilistic admixture or topic models in the overcomplete regime, where the number of latent topics can greatly exceed the size of the observed word vocabulary. While general overcomplete topic models are not identifiable, we establish <i>generic</i> identifiability under a constraint, referred to as <i>topic persistence</i>. Our sufficient conditions for identifiability involve a novel set of \"higher order\" expansion conditions on the <i>topic-word matrix</i> or the <i>population structure</i> of the model. This set of higher-order expansion conditions allow for overcomplete models, and require the existence of a perfect matching from latent topics to higher order observed words. We establish that random structured topic models are identifiable w.h.p. in the overcomplete regime. Our identifiability results allows for general (non-degenerate) distributions for modeling the topic proportions, and thus, we can handle arbitrarily correlated topics in our framework. Our identifiability results imply uniqueness of a class of tensor decompositions with structured sparsity which is contained in the class of <i>Tucker</i> decompositions, but is more general than the <i>Candecomp/Parafac</i> (CP) decomposition.",
     "authors": [
-        "Animashree An",
-        "kumar",
+        "Animashree Anandkumar",
         "Daniel Hsu",
         "Majid Janzamin",
         "Sham Kakade"

--- a/dasilva15a/dasilva15a.bib
+++ b/dasilva15a/dasilva15a.bib
@@ -1,5 +1,5 @@
 @article{JMLR:v16:dasilva15a,
-  author  = {Cleomar Pereira da Silva and Douglas Mota Dias and Cristiana Bentes and Marco Aur\'{e}lio Cavalcanti Pacheco and Leandro Fontoura Cupertino},
+  author  = {Cleomar Pereira da Silva and Douglas Mota Dias and Cristiana Bentes and Marco Aurélio Cavalcanti Pacheco and Leandro Fontoura Cupertino},
   title   = {Evolving GPU Machine Code},
   journal = {Journal of Machine Learning Research},
   year    = {2015},

--- a/dasilva15a/info.json
+++ b/dasilva15a/info.json
@@ -4,9 +4,8 @@
         "Cleomar Pereira da Silva",
         "Douglas Mota Dias",
         "Cristiana Bentes",
-        "Marco Aur{{\\'e}}lio Cavalcanti Pacheco",
-        "Le",
-        "ro Fontoura Cupertino"
+        "Marco Aurélio Cavalcanti Pacheco",
+        "Leandro Fontoura Cupertino"
     ],
     "id": "dasilva15a",
     "issue": 22,

--- a/garcia15a/garcia15a.bib
+++ b/garcia15a/garcia15a.bib
@@ -1,5 +1,5 @@
 @article{JMLR:v16:garcia15a,
-  author  = {Javier Garc{{\'i}}a and Fernando Fern{{\'a}}ndez},
+  author  = {Javier García and Fernando Fernández},
   title   = {A Comprehensive Survey on Safe Reinforcement Learning},
   journal = {Journal of Machine Learning Research},
   year    = {2015},

--- a/garcia15a/info.json
+++ b/garcia15a/info.json
@@ -1,9 +1,8 @@
 {
     "abstract": "Safe Reinforcement Learning can be defined as the process of learning policies that maximize the expectation of the return in problems in which it is important to ensure reasonable system performance and/or respect safety constraints during the learning and/or deployment processes. We categorize and analyze two approaches of Safe Reinforcement Learning. The first is based on the modification of the optimality criterion, the classic discounted finite/infinite horizon, with a safety factor. The second is based on the modification of the exploration process through the incorporation of external knowledge or the guidance of a risk metric. We use the proposed classification to survey the existing literature, as well as suggesting future directions for Safe Reinforcement Learning.",
     "authors": [
-        "Javier Garc{{\\'i}}a",
-        "Fern",
-        "o Fern{{\\'a}}ndez"
+        "Javier García",
+        "Fernando Fernández"
     ],
     "id": "garcia15a",
     "issue": 42,

--- a/huang15a/info.json
+++ b/huang15a/info.json
@@ -4,8 +4,7 @@
         "Furong Huang",
         "U. N. Niranjan",
         "Mohammad Umar Hakeem",
-        "Animashree An",
-        "kumar"
+        "Animashree Anandkumar"
     ],
     "id": "huang15a",
     "issue": 86,

--- a/lopezpaz15a/info.json
+++ b/lopezpaz15a/info.json
@@ -2,8 +2,7 @@
     "abstract": "We are interested in learning causal relationships between pairs of random variables, purely from observational data. To effectively address this task, the state-of-the-art relies on strong assumptions on the mechanisms mapping causes to effects, such as invertibility or the existence of additive noise, which only hold in limited situations. On the contrary, this short paper proposes to <i>learn</i> how to perform causal inference directly from data, without the need of feature engineering. In particular, we pose causality as a kernel mean embedding classification problem, where inputs are samples from arbitrary probability distributions on pairs of random variables, and labels are types of causal relationships. We validate the performance of our method on synthetic and real-world data against the state-of-the-art. Moreover, we submitted our algorithm to the ChaLearn's \"Fast Causation Coefficient Challenge\" competition, with which we won the fastest code prize and ranked third in the overall leaderboard.",
     "authors": [
         "David Lopez-Paz",
-        "Krikamol Mu",
-        "et",
+        "Krikamol Muandet",
         "Benjamin Recht"
     ],
     "id": "lopezpaz15a",

--- a/mokhtari15a/info.json
+++ b/mokhtari15a/info.json
@@ -2,8 +2,7 @@
     "abstract": "Global convergence of an online (stochastic) limited memory version of the Broyden-Fletcher-Goldfarb-Shanno (BFGS) quasi- Newton method for solving optimization problems with stochastic objectives that arise in large scale machine learning is established. Lower and upper bounds on the Hessian eigenvalues of the sample functions are shown to suffice to guarantee that the curvature approximation matrices have bounded determinants and traces, which, in turn, permits establishing convergence to optimal arguments with probability 1. Experimental evaluation on a search engine advertising problem showcase reductions in convergence time relative to stochastic gradient descent algorithms.",
     "authors": [
         "Aryan Mokhtari",
-        "Alej",
-        "ro Ribeiro"
+        "Alejandro Ribeiro"
     ],
     "id": "mokhtari15a",
     "issue": 98,

--- a/moreno15a/info.json
+++ b/moreno15a/info.json
@@ -4,8 +4,7 @@
         "Pablo G. Moreno",
         "Antonio Artes-Rodriguez",
         "Yee Whye Teh",
-        "Fern",
-        "o Perez-Cruz"
+        "Fernando Perez-Cruz"
     ],
     "id": "moreno15a",
     "issue": 48,

--- a/prasse15a/info.json
+++ b/prasse15a/info.json
@@ -3,8 +3,7 @@
     "authors": [
         "Paul Prasse",
         "Christoph Sawade",
-        "Niels L",
-        "wehr",
+        "Niels Landwehr",
         "Tobias Scheffer"
     ],
     "id": "prasse15a",


### PR DESCRIPTION
Author name typo fix (accidently splited during parsing author name list)